### PR TITLE
Security feature request: Add "umask" option

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+0.0052_01 patched at https://github.com/haukex/Daemon-Daemonize
+    - Added "umask" option
+
 0.0052 Wednesday June 09 13:31:02 PDT 2010:
     - Added pgrep check to t/9-basic.t
 

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     Daemon::Daemonize - An easy-to-use daemon(izing) toolkit
 
 VERSION
-    version 0.0052
+    version 0.0052_01
 
 SYNOPSIS
         use Daemon::Daemonize qw/ :all /

--- a/dzpl
+++ b/dzpl
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use Dzpl
     name => 'Daemon-Daemonize',
-    version => '0.0052',
+    version => '0.0052_01',
     author => 'Robert Krimen <robertkrimen@gmail.com>',
     license => 'Perl5',
     copyright => 'Robert Krimen',

--- a/lib/Daemon/Daemonize.pm
+++ b/lib/Daemon/Daemonize.pm
@@ -130,6 +130,10 @@ Daemonize the current process, according to C<%options>:
 
     run <code>          After daemonizing, run the given code and then exit
 
+    umask <umask>       Set the umask to this value (the default is 0, meaning files
+                        will typically have 666 permissions). Note this value should
+                        not be a string; use e.g. oct($string) to convert a string.
+
 =cut
 
 sub daemonize {
@@ -170,8 +174,8 @@ sub daemonize {
     # Fork again to ensure that daemon never reacquires a control terminal
     $self->_fork_or_die && exit 0;
 
-    # Clear the file creation mask
-    umask 0;
+    # Set the file creation mask
+    umask( defined $options{umask} ? $options{umask} : 0 );
 
     if ( defined $chdir ) {
         chdir $chdir or confess "Unable to chdir to \"$chdir\": $!";

--- a/lib/Daemon/Daemonize.pm
+++ b/lib/Daemon/Daemonize.pm
@@ -1,4 +1,8 @@
 package Daemon::Daemonize;
+BEGIN {
+  $Daemon::Daemonize::VERSION = '0.0052_01'; # patched at https://github.com/haukex/Daemon-Daemonize
+  $Daemon::Daemonize::VERSION = eval $Daemon::Daemonize::VERSION; # recommended by perlmodstyle
+}
 # ABSTRACT: An easy-to-use daemon(izing) toolkit
 
 use warnings;

--- a/t/05-umask.t
+++ b/t/05-umask.t
@@ -1,0 +1,49 @@
+#!/usr/bin/env perl
+use warnings;
+use strict;
+
+use Test::More;
+
+use Path::Class qw/ tempdir /;
+use Daemon::Daemonize;
+
+my $shibboleth = $$ + substr int( rand time ), 6;
+my $dollar_0 = "d-d-test-$shibboleth";
+
+my $tmpdir = tempdir(CLEANUP=>1);
+my $pid_file = $tmpdir->file($shibboleth)->absolute;
+my $stdout_file = $tmpdir->file("stdout")->absolute;
+my $stderr_file = $tmpdir->file("stderr")->absolute;
+my $want_umask = oct('0027');
+
+Daemon::Daemonize->daemonize(
+	umask => $want_umask,
+	stdout => $stdout_file,
+	stderr => $stderr_file,
+	run => sub {
+		local $0 = $dollar_0;
+		Daemon::Daemonize->write_pidfile($pid_file);
+		print STDOUT sprintf("%04o",umask);
+		print STDERR "I am stderr";
+		sleep 10;
+	}
+);
+
+sleep 1;
+
+my $pid = Daemon::Daemonize->check_pidfile($pid_file);
+ok $pid, "checked pid $pid";
+
+my $umask = $stdout_file->slurp;
+is $umask, '0027', "umask $umask is correct";
+
+is $stderr_file->slurp, "I am stderr", "stderr file is correct";
+
+my    $pid_mode =    $pid_file->stat->mode;
+ok( (   $pid_mode&$want_umask)==0, sprintf("   PID file mode %o is masked ok",    $pid_mode) );
+my $stdout_mode = $stdout_file->stat->mode;
+ok( ($stdout_mode&$want_umask)==0, sprintf("STDOUT file mode %o is masked ok", $stdout_mode) );
+my $stderr_mode = $stderr_file->stat->mode;
+ok( ($stderr_mode&$want_umask)==0, sprintf("STDERR file mode %o is masked ok", $stderr_mode) );
+
+done_testing;


### PR DESCRIPTION
I have written a daemon using `Daemon::Daemonize` that starts out as root and then reduces its permissions by setting its own PID and GID. However, because the umask is cleared in the `daemonize` function, I end up with three files (PID, STDOUT, STDERR) that are 666 owned by root, which is not a Good Thing (even if I later change the permissions of those files).
This commit adds a "umask" option that allows the user to choose the umask, while preserving backwards compatibility (the previous behavior is the default in case the option isn't specified).
